### PR TITLE
Fix plugin exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Instead of using `Vue.use(JoditVue)` you can use the component locally
 
 <script>
 import 'jodit/build/jodit.min.css'
-import JoditVue from 'jodit-vue'
+import { JoditVue } from 'jodit-vue'
 
 export default {
     name: 'app',
@@ -91,7 +91,7 @@ When providing the buttons to show on the editor you will need to provide an arr
 
 <script>
 import 'jodit/build/jodit.min.css'
-import JoditVue from 'jodit-vue'
+import { JoditVue } from 'jodit-vue'
 
 export default {
     name: 'app',
@@ -121,7 +121,7 @@ If you need to create custom buttons to the editor, you can create them and prov
 
 <script>
 import 'jodit/build/jodit.min.css'
-import JoditVue from 'jodit-vue'
+import { JoditVue } from 'jodit-vue'
 
 export default {
     name: 'app',

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -16,5 +16,6 @@ else if (typeof global !== 'undefined') GlobalVue = global.Vue
 
 if (GlobalVue) GlobalVue.use(plugin)
 
-export default JoditVue
+export default plugin
+export { JoditVue }
 export { default as Jodit } from 'jodit'


### PR DESCRIPTION
This PR fixes plugin exports to enable both global component registration using:
```js
import JoditVue from 'jodit-vue'

Vue.use(JoditVue)
```

and per component local registration using:
```js
<script>
import { JoditVue } from 'jodit-vue'

export default {
  components: { JoditVue }
}
</script>
```