### PR TITLE
Rename `JoditVue` component to `JoditEditor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ Instead of using `Vue.use(JoditVue)` you can use the component locally
 ```vue
 <template>
     <div id="app">
-        <jodit-vue v-model="content" />
+        <jodit-editor v-model="content" />
     </div>
 </template>
 
 <script>
 import 'jodit/build/jodit.min.css'
-import { JoditVue } from 'jodit-vue'
+import { JoditEditor } from 'jodit-vue'
 
 export default {
     name: 'app',
 
-    components: { JoditVue },
+    components: { JoditEditor },
 
     data () {
         return {
@@ -85,18 +85,18 @@ When providing the buttons to show on the editor you will need to provide an arr
 ```vue
 <template>
     <div id="app">
-        <jodit-vue v-model="content" :buttons="buttons" />
+        <jodit-editor v-model="content" :buttons="buttons" />
     </div>
 </template>
 
 <script>
 import 'jodit/build/jodit.min.css'
-import { JoditVue } from 'jodit-vue'
+import { JoditEditor } from 'jodit-vue'
 
 export default {
     name: 'app',
 
-    components: { JoditVue },
+    components: { JoditEditor },
 
     data () {
         return {
@@ -115,18 +115,18 @@ If you need to create custom buttons to the editor, you can create them and prov
 ```vue
 <template>
     <div id="app">
-        <jodit-vue v-model="content" :buttons="buttons" :extra-buttons="customButtons" />
+        <jodit-editor v-model="content" :buttons="buttons" :extra-buttons="customButtons" />
     </div>
 </template>
 
 <script>
 import 'jodit/build/jodit.min.css'
-import { JoditVue } from 'jodit-vue'
+import { JoditEditor } from 'jodit-vue'
 
 export default {
     name: 'app',
 
-    components: { JoditVue },
+    components: { JoditEditor },
 
     data () {
         return {

--- a/src/JoditEditor.vue
+++ b/src/JoditEditor.vue
@@ -6,7 +6,7 @@
 import Jodit from 'jodit'
 
 export default {
-  name: 'JoditVue',
+  name: 'JoditEditor',
 
   props: {
     value: { type: String, required: true },

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -1,11 +1,13 @@
 /* eslint-env node */
 
-import JoditVue from './JoditVue.vue'
+import JoditEditor from './JoditEditor.vue'
 
 export function install (Vue) {
   if (install.installed) return
   install.installed = true
-  Vue.component('JoditVue', JoditVue)
+  Vue.component('JoditEditor', JoditEditor)
+  // Backwards compatible global component registration
+  Vue.component('JoditVue', JoditEditor)
 }
 
 const plugin = { install }
@@ -17,5 +19,5 @@ else if (typeof global !== 'undefined') GlobalVue = global.Vue
 if (GlobalVue) GlobalVue.use(plugin)
 
 export default plugin
-export { JoditVue }
+export { JoditEditor, JoditEditor as JoditVue }
 export { default as Jodit } from 'jodit'


### PR DESCRIPTION
This PR aligns package in terms of naming with [`jodit-react`](https://github.com/jodit/jodit-react). In the same time backwards compatibility is preserved by globally registering `JoditVue` alias and exposing it for local component registration purposes. 