### PR TITLE
Update `jodit` from 3.2.46 to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "@ungap/global-this": "^0.3.1",
-    "jodit": "^3.2.46"
+    "jodit": "^3.4.1"
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^0.21.1",

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -17,4 +17,4 @@ if (globalThis.Vue) globalThis.Vue.use(plugin)
 
 export default plugin
 export { JoditEditor, JoditEditor as JoditVue }
-export { default as Jodit } from 'jodit'
+export { Jodit } from 'jodit'

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,6 +405,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+autobind-decorator@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.4.0.tgz#ea9e1c98708cf3b5b356f7cf9f10f265ff18239c"
+  integrity sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -1667,10 +1672,12 @@ jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jodit@^3.2.46:
-  version "3.4.14"
-  resolved "https://registry.yarnpkg.com/jodit/-/jodit-3.4.14.tgz#c811ecc807d689f39b28ba1bbf80d9d7a69e0d17"
-  integrity sha512-Mxf3MPr9P+FO8zyRcC4FUJMeGjPMSBenuM5KkB7ZBB1A+2TXDhzq6ACJ6sTXU6u4xWw358zKoBuaARNfdwbcVw==
+jodit@^3.4.1:
+  version "3.4.29"
+  resolved "https://registry.yarnpkg.com/jodit/-/jodit-3.4.29.tgz#fba8d9678b954d5d5ea5015b50628c704f7658a2"
+  integrity sha512-1rW4aBeG5hgdTjNxYOWN2hc51M5O4U3BNdwxaxwLR8pIlrjmeDVxZu2YZ6L4TI1MfFRCpczL0vPzj6hlTFyvng==
+  dependencies:
+    autobind-decorator "^2.4.0"
 
 js-base64@^2.1.9:
   version "2.6.3"


### PR DESCRIPTION
c2b1cb2 updated `jodit` version in `yarn.lock` this mirrors that change inside `package.json` and fixes `Jodit` re-exporting from `wrapper.js`.