### PR TITLE
Edits for Vite and Vue 3 support

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -1,10 +1,9 @@
-import Vue from 'vue'
+import { createApp } from 'vue'
 import App from './App.vue'
 import JoditVue from '../src/wrapper'
 
-Vue.use(JoditVue)
-Vue.config.productionTip = false
+const app = createApp(App)
+app.use(JoditVue)
+app.config.productionTip = false
 
-new Vue({
-  render: h => h(App)
-}).$mount('#app')
+app.mount('#app')

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <link rel="icon" href="/favicon.ico" />
+    <title>Jodit Vue</title>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/example/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "wysiwyg"
   ],
   "scripts": {
-    "serve": "vue-cli-service serve ./example/main.js",
+    "serve": "vite",
     "lint": "eslint --color --ext .js,.vue .",
     "lint:fix": "eslint --color --fix --ext .js,.vue .",
     "clean": "del-cli ./dist",

--- a/src/JoditEditor.vue
+++ b/src/JoditEditor.vue
@@ -49,8 +49,8 @@ export default {
       })
     }
     this.editor = new Jodit(this.$el, this.editorConfig)
-    this.editor.value = this.value
-    this.editor.events.on('change', newValue => this.$emit('input', newValue))
+    this.editor.value = this.modelValue
+    this.editor.events.on('change', newValue => this.$emit('update:modelValue', newValue))
   },
 
   beforeUnmount () {

--- a/vite.config.js
+++ b/vite.config.js
@@ -72,6 +72,14 @@ const config = Object.entries(formats).reduce((acc, [format, filename]) => {
 }, [])
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^~(.*)$/,
+        replacement: 'node_modules/$1'
+      }
+    ]
+  },
   build: {
     lib: {
       entry: path.resolve(__dirname, '/src/wrapper.js'),


### PR DESCRIPTION
This PR makes the following changes:

- [ ] Edit serve command to use Vite
- [ ] Create index.html file to use as entry point for example
- [ ] Edit main.js file for Vue 3 compability